### PR TITLE
configure.ac: remove unneeded check for c++ compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,6 @@ AM_INIT_AUTOMAKE([foreign -Wall])
 AC_CONFIG_HEADERS([config.h])
 
 # Checks for programs.
-AC_PROG_CXX
 AC_PROG_CC
 
 # Checks for libraries.


### PR DESCRIPTION
If the c++ compiler is not present, the build configuration
will fail. This patch remove the check for the c++ compiler
because all the ptm2human code is written in C.

Signed-off-by: Julien Olivain <juju@cotds.org>