### PR TITLE
Respect COMMOPT & unaligned TPIU stream support.

### DIFF
--- a/etb_format.c
+++ b/etb_format.c
@@ -52,12 +52,14 @@ static int init_stream(struct stream *stream, struct stream *parent)
     return 0;
 }
 
-int decode_etb_stream(struct stream *etb_stream)
+int decode_etb_stream(struct stream *etb_stream, int unaligned)
 {
     struct stream *stream;
     int ret = 0;
-    int nr_stream, pkt_idx, byte_idx, id, cur_id, pre_id, nr_new, i, trace_stop = 0;
+    int nr_stream, pkt_idx, byte_idx, id, cur_id, pre_id, nr_new, i, b, trace_stop = 0;
+    int ofs = 0;
     unsigned char c, end, tmp;
+    const unsigned char fsync[] = {0xff,0xff,0xff, 0x7f};
 
     if (!etb_stream) {
         LOGE("Invalid stream pointer\n");
@@ -78,7 +80,22 @@ int decode_etb_stream(struct stream *etb_stream)
         goto exit_decode_etb_stream;
     }
 
-    for (pkt_idx = 0; pkt_idx < etb_stream->buff_len; pkt_idx += ETB_PACKET_SIZE) {
+    if (unaligned) {
+        for (b = 0; b < etb_stream->buff_len-sizeof(fsync)-1; b++) {
+            if (memcmp(&fsync, &etb_stream->buff[b], sizeof(fsync)) == 0) {
+                ofs = b+sizeof(fsync); break;
+            }
+        }
+
+        if (!ofs) {
+            OUTPUT("No FSYNC found.");
+            ret = -1;
+            goto exit_decode_etb_stream;
+        }
+    }
+    else { ofs = 0; }
+
+    for (pkt_idx = ofs; pkt_idx < etb_stream->buff_len; pkt_idx += ETB_PACKET_SIZE) {
         if (trace_stop) {
             break;
         }

--- a/etb_format.c
+++ b/etb_format.c
@@ -88,7 +88,7 @@ int decode_etb_stream(struct stream *etb_stream, int unaligned)
         }
 
         if (!ofs) {
-            OUTPUT("No FSYNC found.");
+            OUTPUT("No FSYNC found.\n");
             ret = -1;
             goto exit_decode_etb_stream;
         }
@@ -99,6 +99,11 @@ int decode_etb_stream(struct stream *etb_stream, int unaligned)
         if (trace_stop) {
             break;
         }
+
+        if (memcmp(&fsync, &etb_stream->buff[pkt_idx], sizeof(fsync)) == 0) {
+            pkt_idx = pkt_idx+sizeof(fsync);
+        }
+
         end = etb_stream->buff[pkt_idx + ETB_PACKET_SIZE - 1];
         for (byte_idx = 0; byte_idx < (ETB_PACKET_SIZE - 1); byte_idx++) {
             c = etb_stream->buff[pkt_idx + byte_idx];

--- a/etb_format.c
+++ b/etb_format.c
@@ -59,7 +59,7 @@ int decode_etb_stream(struct stream *etb_stream, int unaligned)
     int nr_stream, pkt_idx, byte_idx, id, cur_id, pre_id, nr_new, i, b, trace_stop = 0;
     int ofs = 0;
     unsigned char c, end, tmp;
-    const unsigned char fsync[] = {0xff,0xff,0xff, 0x7f};
+    const unsigned char fsync[] = { 0xff, 0xff, 0xff, 0x7f };
 
     if (!etb_stream) {
         LOGE("Invalid stream pointer\n");
@@ -88,7 +88,7 @@ int decode_etb_stream(struct stream *etb_stream, int unaligned)
         }
 
         if (!ofs) {
-            OUTPUT("No FSYNC found.\n");
+            LOGE("No frame synchronization packet found.\n");
             ret = -1;
             goto exit_decode_etb_stream;
         }

--- a/etmv4.c
+++ b/etmv4.c
@@ -326,8 +326,7 @@ DECL_DECODE_FN(cc_format_1)
     unsigned char data;
     unsigned int commit = 0, count = 0;
 
-    /* FIXME: need to get TRCIDR0.COMMOPT */
-    if (1) {
+    if (!COMMOPT(&(stream->tracer))) {
         for (i = 0; i < 4; i++) {
             data = pkt[index++];
             commit |= (data & ~c_bit) << (7 * i);
@@ -394,8 +393,7 @@ DECL_DECODE_FN(cc_format_3)
     BB = (pkt[0] & 0x03);
     LOGD("[cycle count format 3] AA = %d, BB = %x\n", AA, BB);
 
-    /* FIXME: need to get TRCIDR0.COMMOPT */
-    if (1) {
+    if (!COMMOPT(&(stream->tracer))) {
         tracer_commit(&(stream->tracer), AA + 1);
     }
 
@@ -1337,6 +1335,7 @@ int etmv4_synchronization(struct stream *stream)
     LOGD("P0_KEY_MAX = %d\n", P0_KEY_MAX(&(stream->tracer)));
     LOGD("COND_KEY_MAX_INCR = %d\n", COND_KEY_MAX_INCR(&(stream->tracer)));
     LOGD("CONDTYPE = %d\n", CONDTYPE(&(stream->tracer)));
+    LOGD("COMMOPT = %d\n", COMMOPT(&(stream->tracer)));
 
     /* locate an async packet and search for a trace-info packet */
     for (i = 0; i < stream->buff_len; i++) {

--- a/ptm2human.c
+++ b/ptm2human.c
@@ -60,7 +60,7 @@ void usage(void)
     printf("Usage: ptm2human [options] -i /TRACE/FILE/PATH\n");
     printf("Options:\n");
     printf("  -i|--input <trace file>                 Give the trace file\n");
-    printf("  -u|--unaligned                          Trace is unaligned and needs to be aligned by FSYNC\n\n");
+    printf("  -u|--unaligned                          Trace is unaligned and needs to be aligned by frame synchronization packet\n\n");
     printf("  -p|--decode-ptm (default option)        Decode PTM trace\n");
     printf("  -c|--context <context ID size>          Give the size of ContextID for PTM trace only\n");
     printf("  -C|--cycle-accurate                     Enable Cycle-Accurate for PTM trace only\n\n");

--- a/ptm2human.c
+++ b/ptm2human.c
@@ -166,7 +166,8 @@ int main(int argc, char **argv)
             if (val == LONG_MAX || val == LONG_MIN || val < 0 || *endptr != '\0' || endptr == optarg) {
                 LOGE("Invalid argument %s\n", optarg);
             } else {
-                CONDTYPE(&(stream.tracer)) = (val & 0x00003000) >> 12;
+                CONDTYPE(&(stream.tracer)) = (val & 0x00003000ul) >> 12;
+                COMMOPT(&(stream.tracer))  = (val & 0x20000000ul) >> 29;
             }
             break;
 

--- a/ptm2human.c
+++ b/ptm2human.c
@@ -38,6 +38,7 @@ int debuglog_on = 0;
 static const struct option options[] = 
 {
     { "input", 1, 0, 'i' },
+    { "unaligned", 0, 0, 'u' },
     { "context", 1, 0, 'c' },
     { "cycle-accurate", 0, 0, 'C' },
     { "decode-ptm", 0, 0, 'p' },
@@ -52,13 +53,14 @@ static const struct option options[] =
     { NULL, 0, 0, 0   },
 };
 
-static const char *optstring = "i:c:Cp0:8:9:2:3:edh";
+static const char *optstring = "i:c:Cp0:8:9:2:3:edhu";
 
 void usage(void)
 {
     printf("Usage: ptm2human [options] -i /TRACE/FILE/PATH\n");
     printf("Options:\n");
-    printf("  -i|--input <trace file>                 Give the trace file\n\n");
+    printf("  -i|--input <trace file>                 Give the trace file\n");
+    printf("  -u|--unaligned                          Trace is unaligned and needs to be aligned by FSYNC\n\n");
     printf("  -p|--decode-ptm (default option)        Decode PTM trace\n");
     printf("  -c|--context <context ID size>          Give the size of ContextID for PTM trace only\n");
     printf("  -C|--cycle-accurate                     Enable Cycle-Accurate for PTM trace only\n\n");
@@ -109,6 +111,7 @@ int main(int argc, char **argv)
     long val;
     unsigned int trcidr12 = 0, trcidr13 = 0;
     const char *input_file = NULL;
+    int unaligned = 0;
     struct stream stream;
     struct stat sb;
 
@@ -126,6 +129,9 @@ int main(int argc, char **argv)
         switch (c) {
         case 'i':
             input_file = strdup(optarg);
+            break;
+        case 'u':
+            unaligned = 1;
             break;
 
         case 'c':
@@ -276,7 +282,7 @@ int main(int argc, char **argv)
 
     file2buff(input_file, stream.buff, stream.buff_len);
 
-    ret = decode_etb_stream(&stream);
+    ret = decode_etb_stream(&stream, unaligned);
 
     free((void *)stream.buff);
 

--- a/stream.h
+++ b/stream.h
@@ -43,6 +43,6 @@ struct stream
 };
 
 extern int decode_stream(struct stream *stream);
-extern int decode_etb_stream(struct stream *stream);
+extern int decode_etb_stream(struct stream *etb_stream, int unaligned);
 
 #endif

--- a/tracer-etmv4.h
+++ b/tracer-etmv4.h
@@ -43,6 +43,7 @@ struct etmv4_tracer
        CONDTYPE_APSR      - Provide the value of the APSR condition flags
      */
     int condtype;
+    int commopt;
 
     /* Trace analyzer state between receiving packets */
     unsigned long long timestamp;
@@ -64,6 +65,7 @@ struct etmv4_tracer
 
 #define TRACE_INFO(t) (((struct etmv4_tracer *)(t))->info)
 #define CONDTYPE(t) (((struct etmv4_tracer *)(t))->condtype)
+#define COMMOPT(t) (((struct etmv4_tracer *)(t))->commopt)
 #define TIMESTAMP(t) (((struct etmv4_tracer *)(t))->timestamp)
 #define ADDRESS_REGISTER(t) ((struct etmv4_tracer *)(t))->address_register
 #define RESET_ADDRESS_REGISTER(t)   \


### PR DESCRIPTION
Extracts COMMOPT value from TRCIDR0 value for ETMv4 and takes care when decoding cycle count format elements.