### PR TITLE
Fix short_address decoding error in Thumb mode

### DIFF
--- a/etmv4.c
+++ b/etmv4.c
@@ -681,7 +681,7 @@ DECL_DECODE_FN(short_address)
         address |= (unsigned long long)(pkt[index++] & 0x7F) << 1;
         if (pkt[1] & c_bit) {
             address &= ~0x0000FF00LL;
-            address &= (unsigned long long)pkt[index++] << 8;
+            address |= (unsigned long long)pkt[index++] << 8;
         }
     }
 


### PR DESCRIPTION
Fix short_address decoding error in Thumb mode

According to the etm specification, the decoding process of the short address is as follows: 

```
when '10010110'
    IS = 1;
    address = address & ~0xFF;
    address = address | (A<7:1> << 1);
    if (C) then
        address = address & ~0xFF00;
        address = address | (A<15:8> << 8);
```